### PR TITLE
Compiling on Kilted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,24 @@ add_library(tcp_interface SHARED
   src/network_interfaces/tcp_interface.cpp
 )
 
-ament_target_dependencies(network_bridge pluginlib rclcpp std_msgs)
-ament_target_dependencies(udp_interface pluginlib rclcpp)
-ament_target_dependencies(tcp_interface pluginlib rclcpp)
+target_link_libraries(network_bridge PUBLIC
+	${std_msgs_TARGETS}
+	pluginlib::pluginlib
+	rclcpp::rclcpp
+	${ZSTD_LIBRARIES}
+)
 
-target_link_libraries(network_bridge ${ZSTD_LIBRARIES})
-target_link_libraries(udp_interface ${Boost_LIBRARIES})
-target_link_libraries(tcp_interface ${Boost_LIBRARIES})
+target_link_libraries(udp_interface PUBLIC
+	pluginlib::pluginlib
+	rclcpp::rclcpp
+	${Boost_LIBRARIES}
+)
+
+target_link_libraries(tcp_interface PUBLIC
+	pluginlib::pluginlib
+	rclcpp::rclcpp
+	${Boost_LIBRARIES}
+)
 
 pluginlib_export_plugin_description_file(network_bridge network_interface_plugins.xml)
 

--- a/src/network_bridge.cpp
+++ b/src/network_bridge.cpp
@@ -46,6 +46,7 @@ NetworkBridge::~NetworkBridge()
   network_interface_->close();
   network_interface_.reset();
 
+  network_check_timer_.reset();
   sub_mgrs_.clear();
   timers_.clear();
   publishers_.clear();


### PR DESCRIPTION
Hello (again),

Here is a minor CMake change to compile without warning on kilted, because ament_target_dependency has been deprecated.
It still compiles on humble without warning. I did not test on other distros.

There is a minor fix to try to remove the class unload warning, but this did not fix it. I leave it because it is still better to stop the timer before closing the node. 