### PR TITLE
Add a specific management of TF topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(tf2_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(PkgConfig REQUIRED)
@@ -39,7 +40,11 @@ endif()
 
 include_directories(include)
 
-add_executable(network_bridge src/network_bridge.cpp src/subscription_manager.cpp)
+add_executable(network_bridge
+    src/network_bridge.cpp
+    src/subscription_manager.cpp
+    src/subscription_manager_tf.cpp
+)
 
 add_library(udp_interface SHARED
   src/network_interfaces/udp_interface.cpp
@@ -51,6 +56,7 @@ add_library(tcp_interface SHARED
 
 target_link_libraries(network_bridge PUBLIC
   ${std_msgs_TARGETS}
+  ${tf2_msgs_TARGETS}
   pluginlib::pluginlib
   rclcpp::rclcpp
   ${ZSTD_LIBRARIES}

--- a/include/network_bridge/subscription_manager.hpp
+++ b/include/network_bridge/subscription_manager.hpp
@@ -57,6 +57,8 @@ public:
     const std::string & subscribe_namespace, int zstd_compression_level = 3,
     bool publish_stale_data = false);
 
+  virtual ~SubscriptionManager();
+
   /**
    * @brief Retrieves the data stored in the subscription manager.
    *
@@ -66,13 +68,12 @@ public:
    *
    * @return A constant reference to the vector containing the data.
    */
-  const std::vector<uint8_t> & get_data();
+  virtual bool get_data(std::vector<uint8_t> & data);
 
-  bool has_data() const;
+  virtual bool has_data() const;
 
-  void check_subscription();
+  virtual void check_subscription();
 
-protected:
   /**
    * @brief Sets up a subscription for a given topic.
    *
@@ -81,7 +82,12 @@ protected:
    * This function is called automatically in the constructor and get_data() method.
    * It fails if the topic does not exist or if there are no publishers on this topic.
    */
-  void setup_subscription();
+  virtual void setup_subscription();
+
+protected:
+  virtual void create_subscription(
+    const std::string & topic,
+    const std::string & msg_type, const rclcpp::QoS & qos);
 
   /**
    * @brief Callback function for handling serialized messages.
@@ -145,5 +151,6 @@ protected:
   /**
    * @brief The data buffer for the subscription manager.
    */
+  std::mutex mtx;
   std::vector<uint8_t> data_;
 };

--- a/include/network_bridge/subscription_manager.hpp
+++ b/include/network_bridge/subscription_manager.hpp
@@ -62,16 +62,26 @@ public:
   /**
    * @brief Retrieves the data stored in the subscription manager.
    *
-   * This method returns a constant reference to the vector containing the stored data.
-   * If no data has been received or if the data is stale and the flag publish_stale_data_ is false,
-   * an empty vector is returned.
+   * This method copies the data in the provided vector under the protection
+   * of an internal mutex.
+   * Return false if no data has been received or if the data is stale and
+   * the flag publish_stale_data_ is false,
    *
-   * @return A constant reference to the vector containing the data.
+   * @return a boolean flag indicating if the data is valid
    */
   virtual bool get_data(std::vector<uint8_t> & data);
 
+  /**
+   * @brief Check if data is available
+   *
+   * @return a boolean flag indicating if the data is valid
+   */
   virtual bool has_data() const;
 
+  /**
+   * @brief Check if the subscription has been successful, or try to set it up
+   *
+   */
   virtual void check_subscription();
 
   /**
@@ -84,6 +94,13 @@ public:
    */
   virtual void setup_subscription();
 
+  /**
+   * @brief Create the subscriber
+   *
+   * This function creates the actual subscriber after setup-subscription has
+   * handled the qos and other params. Can be overloaded by specialized
+   * subscribers
+   */
   virtual void create_subscription(
     const std::string & topic,
     const std::string & msg_type, const rclcpp::QoS & qos);

--- a/include/network_bridge/subscription_manager_tf.hpp
+++ b/include/network_bridge/subscription_manager_tf.hpp
@@ -1,0 +1,83 @@
+/*
+==============================================================================
+MIT License
+
+Copyright (c) 2024 Ethan M Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+==============================================================================
+*/
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialization.hpp>
+#include <tf2_msgs/msg/tf_message.hpp>
+
+#include <network_bridge/subscription_manager.hpp>
+
+/**
+ * @class SubscriptionManager
+ * @brief Manages and stores data of subscriptions to a specific topic.
+ *
+ * The SubscriptionManager class is responsible for managing and storing data of subscriptions to a specific topic.
+ * It provides methods to retrieve the stored data and set up subscriptions for the topic.
+ */
+class SubscriptionManagerTF : public SubscriptionManager
+{
+public:
+  /**
+   * @brief Constructs a SubscriptionManager object.
+   *
+   * This constructor initializes a SubscriptionManager object with the given parameters.
+   *
+   * @param node A pointer to the rclcpp::Node object.
+   * @param topic The topic to subscribe to.
+   * @param zstd_compression_level The compression level for Zstandard compression (default: 3).
+   * @param namespace The namespace for the subscription.
+   * @param publish_stale_data Flag indicating whether to publish stale data (default: false).
+   */
+  SubscriptionManagerTF(
+    const rclcpp::Node::SharedPtr & node, const std::string & topic,
+    const std::string & subscribe_namespace, int zstd_compression_level = 3,
+    bool publish_stale_data = false, bool static_tf = false);
+
+  virtual ~SubscriptionManagerTF();
+
+  void check_subscription() override;
+
+protected:
+  void create_subscription(
+    const std::string & topic,
+    const std::string & msg_type, const rclcpp::QoS & qos) override;
+
+  void tf2_callback(
+    const std::shared_ptr<const tf2_msgs::msg::TFMessage> & tfmsg);
+
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf2_subscriber_;
+
+  rclcpp::Serialization<tf2_msgs::msg::TFMessage> tf2_serialization_;
+  std::map<std::pair<std::string, std::string>, size_t> tf_id_;
+  tf2_msgs::msg::TFMessage tfs_;
+
+  bool static_tf_;
+};

--- a/include/network_bridge/thrift_stream.hpp
+++ b/include/network_bridge/thrift_stream.hpp
@@ -16,8 +16,6 @@ public:
 
   virtual void shutdown() = 0;
 
-  virtual bool skipToNextMessage() = 0;
-
   virtual bool readBytes(std::vector<uint8_t> & bytes, size_t len) = 0;
 
   virtual size_t readSome(std::vector<uint8_t> & bytes, size_t maxlen) = 0;
@@ -25,29 +23,6 @@ public:
   virtual int available()
   {
     return -1;             // not implemented
-  }
-
-protected:
-  bool recording;
-  std::list<uint8_t> R;           // byte recording
-
-public:
-  void startRecording()
-  {
-    R.clear();
-    recording = true;
-    // std::cout << "Start recording " << std::endl;
-  }
-
-  void stopRecording()
-  {
-    recording = false;
-    // std::cout << "Stop recording: " << R.size() << std::endl;
-  }
-
-  const std::list<uint8_t> getRecording() const
-  {
-    return R;
   }
 
 public:

--- a/include/network_interfaces/tcp_interface.hpp
+++ b/include/network_interfaces/tcp_interface.hpp
@@ -107,6 +107,7 @@ private:
   int port_;
   bool ready_;
   bool failed_;
+  bool shutting_down_;
 
   io_context io_context_;
   std::shared_ptr<tcp::socket> socket_;

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <depend>libboost-system-dev</depend>
   <depend>libzstd-dev</depend>
   <depend>std_msgs</depend>
+  <depend>tf2_msgs</depend>
   <depend>pluginlib</depend>
 
 

--- a/src/network_bridge.cpp
+++ b/src/network_bridge.cpp
@@ -35,6 +35,7 @@ SOFTWARE.
 #include <pluginlib/class_loader.hpp>
 #include <std_msgs/msg/string.hpp>
 
+#include "network_bridge/subscription_manager_tf.hpp"
 #include "network_interfaces/network_interface_base.hpp"
 
 NetworkBridge::NetworkBridge(const std::string & node_name)
@@ -55,6 +56,7 @@ void NetworkBridge::initialize()
 
 void NetworkBridge::shutdown()
 {
+  RCLCPP_INFO(this->get_logger(), "NetworkBridge: Shuting down");
   if (network_interface_) {
     network_interface_->close();
   }
@@ -129,33 +131,67 @@ void NetworkBridge::load_parameters()
   for (const auto & topic : topics) {
     std::string rate_param_name = topic + ".rate";
     std::string zstd_level_param_name = topic + ".zstd_level";
+    std::string is_tf_param_name = topic + ".is_tf";
+    bool is_tf = (topic == "/tf") || (topic == "tf") || (topic == "/tf_static") ||
+      (topic == "tf_static");
+    bool is_static_tf = is_tf && ((topic == "/tf_static") || (topic == "tf_static"));
+    float rate = 1;
+    int zstd_level = 3;
 
-    this->declare_parameter<double>(rate_param_name, default_rate);
+
     this->declare_parameter<int>(zstd_level_param_name, default_zstd_level);
-
-    float rate;
-    int zstd_level;
-
+    // Add this parameter to force the tf nature if needed
+    this->declare_parameter<bool>(is_tf_param_name, is_tf);
+    this->declare_parameter<double>(rate_param_name, default_rate);
+    this->get_parameter(is_tf_param_name, is_tf);
     this->get_parameter(rate_param_name, rate);
     this->get_parameter(zstd_level_param_name, zstd_level);
 
-    auto manager = std::make_shared<SubscriptionManager>(
-      shared_from_this(), topic, subscribe_namespace,
-      zstd_level, publish_stale_data);
-    sub_mgrs_.push_back(manager);
+    if (is_tf) {
+      // Add this parameter to force the static tf nature if needed
+      std::string is_static_tf_param_name = topic + ".is_static_tf";
+      this->declare_parameter<bool>(is_static_tf_param_name, is_static_tf);
 
-    int ms = static_cast<int>(1000.0 / rate);
-    auto timer = this->create_wall_timer(
-      std::chrono::milliseconds(ms),
-      [this, manager]() {
-        send_data(manager);
-      });
+      this->get_parameter(is_static_tf_param_name, is_static_tf);
 
-    timers_.push_back(timer);
+      std::shared_ptr<SubscriptionManager> manager(new SubscriptionManagerTF(
+          shared_from_this(), topic, subscribe_namespace,
+          zstd_level, publish_stale_data, is_static_tf));
+      manager->setup_subscription();
+      sub_mgrs_.push_back(manager);
 
-    RCLCPP_INFO(
-      this->get_logger(),
-      "Topic: %s, Rate: %f Hz", topic.c_str(), rate);
+      // TODO: specialize this
+      int ms = static_cast<int>(1000.0 / rate);
+      auto timer = this->create_wall_timer(
+        std::chrono::milliseconds(ms),
+        [this, manager]() {
+          send_data(manager);
+        });
+
+      timers_.push_back(timer);
+      RCLCPP_INFO(
+        this->get_logger(),
+        "TF Topic: %s, Rate: %f Hz", topic.c_str(), rate);
+    } else {
+      auto manager = std::make_shared<SubscriptionManager>(
+        shared_from_this(), topic, subscribe_namespace,
+        zstd_level, publish_stale_data);
+      manager->setup_subscription();
+      sub_mgrs_.push_back(manager);
+
+      int ms = static_cast<int>(1000.0 / rate);
+      auto timer = this->create_wall_timer(
+        std::chrono::milliseconds(ms),
+        [this, manager]() {
+          send_data(manager);
+        });
+
+      timers_.push_back(timer);
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Topic: %s, Rate: %f Hz", topic.c_str(), rate);
+    }
+
   }
 
   network_check_timer_ = this->create_wall_timer(
@@ -282,9 +318,8 @@ void NetworkBridge::send_data(std::shared_ptr<SubscriptionManager> manager)
     return;
   }
 
-  const std::vector<uint8_t> & data = manager->get_data();
-
-  if (data.empty()) {
+  std::vector<uint8_t> data;
+  if (!manager->get_data(data)) {
     RCLCPP_WARN(
       this->get_logger(),
       "SubscriptionManager %s has no data", manager->topic_.c_str());

--- a/src/network_interfaces/tcp_interface.cpp
+++ b/src/network_interfaces/tcp_interface.cpp
@@ -56,6 +56,7 @@ void TcpInterface::load_parameters()
 
 void TcpInterface::open()
 {
+  shutting_down_ = false;
   failed_ = false;
   ready_ = false;
   io_context_.restart();
@@ -90,6 +91,7 @@ bool TcpInterface::has_failed() const
 
 void TcpInterface::close()
 {
+  shutting_down_ = true;
   if (acceptor_) {
     acceptor_->close();
   }
@@ -173,7 +175,7 @@ void TcpInterface::receive_thread()
 void TcpInterface::setup_server()
 {
   boost::system::error_code ec;
-  bool fatal = true;
+  bool fatal = !shutting_down_;
 
   tcp::endpoint endpoint(tcp::v4(), port_);
 
@@ -182,35 +184,41 @@ void TcpInterface::setup_server()
 
   acceptor_->open(endpoint.protocol(), ec);
   error_handler(ec, "Failed to open acceptor", fatal);
+  if (shutting_down_) {return;}
 
   acceptor_->set_option(tcp::acceptor::reuse_address(true), ec);
   error_handler(ec, "Failed to set acceptor option", fatal);
+  if (shutting_down_) {return;}
 
   acceptor_->bind(endpoint, ec);
   error_handler(ec, "Failed to bind acceptor", fatal);
+  if (shutting_down_) {return;}
 
   acceptor_->listen(tcp::socket::max_listen_connections, ec);
   error_handler(ec, "Failed to listen on acceptor", fatal);
+  if (shutting_down_) {return;}
 
   RCLCPP_INFO(node_->get_logger(), "Accepting connections");
   acceptor_->async_accept(
     *socket_,
     [this](const boost::system::error_code & ec) {
-      error_handler(ec, "Failed to accept connection", true);
-      RCLCPP_INFO(
-        node_->get_logger(),
-        "Accepted connection from %s:%u",
-        socket_->remote_endpoint().address().to_string().c_str(),
-        socket_->remote_endpoint().port());
-      ready_ = true;
-      start_receive();
+      error_handler(ec, "Failed to accept connection", !shutting_down_);
+      if (!shutting_down_) {
+        RCLCPP_INFO(
+          node_->get_logger(),
+          "Accepted connection from %s:%u",
+          socket_->remote_endpoint().address().to_string().c_str(),
+          socket_->remote_endpoint().port());
+        ready_ = true;
+        start_receive();
+      }
     });
 }
 
 void TcpInterface::setup_client()
 {
   boost::system::error_code ec;
-  bool fatal = true;
+  bool fatal = !shutting_down_;
 
   tcp::endpoint endpoint(
     address::from_string(remote_address_), port_);
@@ -242,11 +250,13 @@ void TcpInterface::error_handler(
   bool fatal)
 {
   if (ec) {
-    RCLCPP_ERROR(
-      node_->get_logger(), "%s: %s",
-      error_message.c_str(), ec.message().c_str());
+    if (!shutting_down_) {
+      RCLCPP_ERROR(
+        node_->get_logger(), "%s: %s",
+        error_message.c_str(), ec.message().c_str());
+    }
 
-    if (fatal) {
+    if (fatal && !shutting_down_) {
       RCLCPP_FATAL(node_->get_logger(), "fatal error, shutting down");
       rclcpp::shutdown();
       exit(1);

--- a/src/subscription_manager_tf.cpp
+++ b/src/subscription_manager_tf.cpp
@@ -1,0 +1,87 @@
+/*
+==============================================================================
+MIT License
+
+Copyright (c) 2024 Ethan M Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+==============================================================================
+*/
+
+#include <rclcpp/qos.hpp>
+#include "network_bridge/subscription_manager_tf.hpp"
+
+SubscriptionManagerTF::SubscriptionManagerTF(
+  const rclcpp::Node::SharedPtr & node, const std::string & topic,
+  const std::string & subscribe_namespace, int zstd_compression_level,
+  bool publish_stale_data, bool static_tf)
+: SubscriptionManager(node, topic, subscribe_namespace, zstd_compression_level, publish_stale_data),
+  static_tf_(static_tf)
+{
+}
+
+SubscriptionManagerTF::~SubscriptionManagerTF() {}
+
+
+void SubscriptionManagerTF::check_subscription()
+{
+  if (!tf2_subscriber_) {
+    setup_subscription();
+  }
+}
+
+
+void SubscriptionManagerTF::create_subscription(
+  const std::string & topic,
+  const std::string & /*msg_type*/, const rclcpp::QoS & qos)
+{
+  RCLCPP_INFO(node_->get_logger(), "Creating TF Subscription");
+  tf2_subscriber_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
+    topic, qos,
+    [this](
+      const std::shared_ptr<const tf2_msgs::msg::TFMessage> & tfmsg) {
+      this->tf2_callback(tfmsg);
+    });
+}
+
+void SubscriptionManagerTF::tf2_callback(
+  const std::shared_ptr<const tf2_msgs::msg::TFMessage> & tfmsg)
+{
+  bool new_tf = false;
+  for (size_t i = 0; i < tfmsg->transforms.size(); i++) {
+    const geometry_msgs::msg::TransformStamped t = tfmsg->transforms[i];
+    auto id = std::make_pair(t.header.frame_id, t.child_frame_id);
+    auto it = tf_id_.find(id);
+    if (it == tf_id_.end()) {
+      tf_id_[id] = tfs_.transforms.size();
+      tfs_.transforms.push_back(t);
+      new_tf = true;
+    } else {
+      tfs_.transforms[it->second] = t;
+    }
+  }
+  if (new_tf) {
+    RCLCPP_INFO(
+      node_->get_logger(), "TF %s list contains %lu transforms",
+      topic_.c_str(), tfs_.transforms.size());
+  }
+  std::shared_ptr<rclcpp::SerializedMessage> serialized_msg(new rclcpp::SerializedMessage);
+  tf2_serialization_.serialize_message(&tfs_, serialized_msg.get());
+  callback(serialized_msg);
+}


### PR DESCRIPTION
This PR addresses partially #6 

This PR adds a specific management of TF messages to ensure that no message is lost, even if the messages are sent at a lower rate. The specialization works by accumulating TF frames and sending all of them on the network. The remaining of #6 can probably be implemented in the specialized subscription manager if needed. 

In addition, the PR fixes some bugs that were still leading to segfault/severe warning on exit, and a memory leak on the tcp queue management. It also cleans the Queue class to remove some of the useless code. 

Tested on TCP over a SSH tunnel.