### PR TITLE
Fixing reconnect bug by reinitializing the reception queue.

### DIFF
--- a/src/network_interfaces/tcp_interface.cpp
+++ b/src/network_interfaces/tcp_interface.cpp
@@ -59,6 +59,7 @@ void TcpInterface::open()
   shutting_down_ = false;
   failed_ = false;
   ready_ = false;
+  stream_.reset();
   io_context_.restart();
   if (role_ == "server") {
     setup_server();

--- a/src/subscription_manager.cpp
+++ b/src/subscription_manager.cpp
@@ -55,7 +55,7 @@ void SubscriptionManager::setup_subscription()
   std::string topic = subscribe_namespace_ + topic_;
 
   if (all_topics_and_types.find(topic) == all_topics_and_types.end()) {
-    if (topic_found_) {
+    if (topic_found_) { // If we thought is was found but we cannot find it.
       RCLCPP_WARN(node_->get_logger(), "Topic %s not found", topic.c_str());
     }
     topic_found_ = false;
@@ -113,6 +113,9 @@ void SubscriptionManager::create_subscription(
       const std::shared_ptr<const rclcpp::SerializedMessage> & serialized_msg) {
       this->callback(serialized_msg);
     });
+  RCLCPP_INFO(
+    node_->get_logger(),
+    "Created generic subscriber for topic %s", topic.c_str());
 }
 
 void SubscriptionManager::callback(


### PR DESCRIPTION
Sorry for yet another PR. I found out that the reception thread in server mode was not reinitialized correctly on reconnecting on the TCP interface. This PR is mostly to fix that.

In the meantime, I had cleaned a bit the TF subscription_manager and forced the timestamp on the static tf message, so I also include it in the PR, even though there is no functional change. 